### PR TITLE
Update Github Actions workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,10 +14,10 @@ jobs:
         run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build container image

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,19 +12,14 @@ jobs:
     steps:
       - name: Set version
         run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - name: Check out the repo
-        uses: actions/checkout@v2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build container image
-        uses: docker/build-push-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
           push: true
-          build-args: |
-            VERSION=${{ env.VERSION }}
-          tags: |
-            docker.pkg.github.com/${{ github.repository }}/plv8:${{ env.VERSION }}
+          tags: ghcr.io/user/plv8:${{ env.VERSION }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -10,8 +10,6 @@ jobs:
       packages: write
       contents: read
     steps:
-      - name: Set version
-        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -22,4 +20,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ghcr.io/user/plv8:${{ env.VERSION }}
+          tags: ghcr.io/user/plv8:${{ github.ref }}


### PR DESCRIPTION
GitHub Actions workflow のバージョンが古くなっていたので最新化する

* docker/build-push-action v2 -> v5
* docker/login-action v1 -> v3